### PR TITLE
Adjustments to defaults

### DIFF
--- a/DonateSpareChange/qt.py
+++ b/DonateSpareChange/qt.py
@@ -882,7 +882,7 @@ class Instance(QWidget, PrintError):
                     (True, "eatBCH", "pp8skudq3x5hzw8ew7vzsw8tn4k8wxsqsv0lt0mf3g"),
                     (True, "eatBCH_SS", "qrsrvtc95gg8rrag7dge3jlnfs4j9pe0ugrmeml950"),
                     (True, "Coins4Clothes", "qzx4tqcldmvs4up9mewkf3ru0z6vy9wm6qm782fwla"),
-                    (True, "Cashshuffle", "qqqxxmjyavdkwdj6npa5w6xl0fzq3wc5furaqdpl59"),
+                    (True, "CashShuffle", "qqqxxmjyavdkwdj6npa5w6xl0fzq3wc5furaqdpl59"),
                     (True, "Electron-Cash", "qz4wq9m860zr5p2nfdpttm5ymdqdyt3psc95qjagae"),
                     (False, "Calin", "qplw0d304x9fshz420lkvys2jxup38m9symky6k028"),
                 ]

--- a/DonateSpareChange/qt.py
+++ b/DonateSpareChange/qt.py
@@ -882,9 +882,11 @@ class Instance(QWidget, PrintError):
                     (True, "eatBCH", "pp8skudq3x5hzw8ew7vzsw8tn4k8wxsqsv0lt0mf3g"),
                     (True, "eatBCH_SS", "qrsrvtc95gg8rrag7dge3jlnfs4j9pe0ugrmeml950"),
                     (True, "Coins4Clothes", "qzx4tqcldmvs4up9mewkf3ru0z6vy9wm6qm782fwla"),
+                    (True, "Cashshuffle", "qqqxxmjyavdkwdj6npa5w6xl0fzq3wc5furaqdpl59"),
+                    (True, "Electron-Cash", "qz4wq9m860zr5p2nfdpttm5ymdqdyt3psc95qjagae"),
                     (False, "Calin", "qplw0d304x9fshz420lkvys2jxup38m9symky6k028"),
                 ]
-                change_def = (10500, 3, 0) # sats, blocks, age_type(not used yet)
+                change_def = (10500, 72, 0) # sats, blocks, age_type(not used yet)
                 d['charities'] = charities
                 d['change_def'] = change_def
                 d['autodonate'] = False


### PR DESCRIPTION
1. Add Cashshuffle and Electron-cash to list - I think their presence is justified, esp. considering the fact that the plugin complements Cashshuffle so well. 
2. Increase donation interval to half a day to allow more "regret" time.