### PR TITLE
Fix timer_interval float error

### DIFF
--- a/DonateSpareChange/qt.py
+++ b/DonateSpareChange/qt.py
@@ -1020,7 +1020,7 @@ class Instance(QWidget, PrintError):
     class Engine(QObject, PrintError):
         ''' The donation engine.  Encapsulates all logic of picking coins to donate, prompting user, setting up Send tab, etc '''
 
-        timer_interval = 10 * 1e3 # value is Qt ms value -- 10 second interval
+        timer_interval = 10000 # value is Qt ms value -- 10 second interval
 
         def __init__(self, parent, wallet, window, co_mgr, data):
             super().__init__(parent) # QObject c'tor


### PR DESCRIPTION
On my Arch box I noticed the error below. Simply changing the initialization of timer_interval was all that was needed. Plugin now works as expected. Figured I should toss up a PR.

```
Traceback (most recent call last):
  File "/usr/lib/python3.10/site-packages/electroncash/plugins.py", line 593, in run_hook
    r = f(*args)
  File "/home/quest/.electron-cash/external_plugins/donate_spare_change.zip/DonateSpareChange/qt.py", line 79, in init_qt
    self.load_wallet(window.wallet, window)
  File "/home/quest/.electron-cash/external_plugins/donate_spare_change.zip/DonateSpareChange/qt.py", line 89, in load_wallet
    self.instances.append(Instance(self, wallet, window))
  File "/home/quest/.electron-cash/external_plugins/donate_spare_change.zip/DonateSpareChange/qt.py", line 163, in __init__
    self.engine = self.Engine(self, self.wallet, self.window, self.co_mgr, self.data)
  File "/home/quest/.electron-cash/external_plugins/donate_spare_change.zip/DonateSpareChange/qt.py", line 1044, in __init__
    self.timer.setInterval(self.timer_interval) # wake up every 10 seconds
TypeError: setInterval(self, int): argument 1 has unexpected type 'float'
```